### PR TITLE
Fixed too thin major roads at early zoom levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "basemapkit",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "exports": {
     ".": {

--- a/src/lib/assets/avenue-layers-raw.txt
+++ b/src/lib/assets/avenue-layers-raw.txt
@@ -1106,7 +1106,7 @@
     }
   },
   {
-    "id": "roads_major_casing_early",
+    "id": "roads_major_casing_early2",
     "type": "line",
     "source": "<BMK_BM_SRC>",
     "source-layer": "roads",
@@ -1115,29 +1115,31 @@
       "all",
       ["!has", "is_tunnel"],
       ["!has", "is_bridge"],
-      ["==", "kind", "major_road"]
+      ["in", "kind", "major_road"]
     ],
     "layout": {"visibility": "visible"},
     "paint": {
-      "line-color": "rgba(194, 194, 194, 1)",
+      "line-color": "#D1CFC7",
       "line-gap-width": [
         "interpolate",
         ["exponential", 1.6],
         ["zoom"],
-        7,
+        3,
         0,
-        7.5,
+        3.5,
         0.5,
         18,
-        13
+        15
       ],
       "line-width": [
         "interpolate",
         ["exponential", 1.6],
         ["zoom"],
-        9,
+        3,
         0,
-        9.5,
+        6,
+        1.3,
+        12,
         1
       ]
     }
@@ -1151,7 +1153,7 @@
       "all",
       ["!has", "is_tunnel"],
       ["!has", "is_bridge"],
-      ["==", "kind", "major_road"]
+      ["in", "kind", "major_road"]
     ],
     "layout": {"visibility": "visible"},
     "paint": {
@@ -1159,14 +1161,16 @@
         "interpolate",
         ["exponential", 1.6],
         ["zoom"],
-        6,
+        3,
         0,
+        6,
+        1.1,
         12,
         1.6,
         15,
-        3,
+        5,
         18,
-        13
+        15
       ],
       "line-color": "#E7E5DE"
     }

--- a/vite.config-lib.ts
+++ b/vite.config-lib.ts
@@ -20,6 +20,7 @@ export default defineConfig({
         "@protomaps/basemaps",
         "maplibre-gl",
         "pmtiles",
+        "color",
       ],
       output: {
         // Provide global variables to use in the UMD build for externalized deps


### PR DESCRIPTION
As mentioned in the issue https://github.com/jonathanlurie/basemapkit/issues/1 the major roads at early zoom levels are so thin they are hardly visible. This is now fixed and major roads now have a style almost as large as highways.

Here are some before/after:

<img width="1124" height="1118" alt="Screenshot from 2025-08-27 14-39-41" src="https://github.com/user-attachments/assets/08ae85eb-d7a4-484a-aa67-b52f58d080c5" />
<img width="1124" height="1118" alt="Screenshot from 2025-08-27 14-40-25" src="https://github.com/user-attachments/assets/abcb5192-e307-4c4b-bfe0-79be38b81402" />

This issue was not limited to the US:
<img width="1124" height="1118" alt="Screenshot from 2025-08-27 14-40-47" src="https://github.com/user-attachments/assets/1fa0bec0-630b-45e4-bdfb-c468c8b13873" />
<img width="1124" height="1118" alt="Screenshot from 2025-08-27 14-41-00" src="https://github.com/user-attachments/assets/0e0d3d07-c0ba-49af-956e-fd51a09d5c61" />

Extra thing part of this PR: the `color` dependency is no longer bundled, making the ES bundle basemapkit quite a lot smaller.
